### PR TITLE
Add Formatters to category list

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "categories": [
     "Other",
+    "Formatters",
     "Languages"
   ],
   "license": "MIT",


### PR DESCRIPTION
The Marketplace has introduce a new category called formatters for extensions that add formatting.
